### PR TITLE
bugfix - issue with running LCOV coverage for files who are in plugins that have similar names

### DIFF
--- a/src/main/java/org/haplo/javascript/debugger/LCOVCoverage.java
+++ b/src/main/java/org/haplo/javascript/debugger/LCOVCoverage.java
@@ -175,7 +175,7 @@
                      Optional<Map.Entry<String, String>> pluginPathOpt = pluginToPluginLocation
                          .entrySet()
                          .stream()
-                         .filter(entry -> filename.contains(entry.getKey()))
+                         .filter(entry -> filename.contains("/" + entry.getKey() + "/"))
                          .findFirst();
                      if (!pluginPathOpt.isPresent()) {
                          return null;


### PR DESCRIPTION
fixed error that occurs when resolving plugin paths for files whose plugins have similar names (e.g. cool_plugin, cool_plugin_with_extra_stuff)